### PR TITLE
Add safety for out of bounds world rain levels

### DIFF
--- a/src/main/java/com/leclowndu93150/particlerain/ClientStuff.java
+++ b/src/main/java/com/leclowndu93150/particlerain/ClientStuff.java
@@ -74,7 +74,10 @@ public class ClientStuff {
             if(event.phase == TickEvent.Phase.END){
                 Minecraft minecraft = Minecraft.getInstance();
                 if (!minecraft.isPaused() && minecraft.level != null && minecraft.getCameraEntity() != null) {
+                    // Profiler phase to find the source of lag when combined with other mods
+                    minecraft.getProfiler().push("updateWeatherParticles");
                     WeatherParticleSpawner.update(minecraft.level, minecraft.getCameraEntity(), minecraft.getFrameTimeNs());
+                    minecraft.getProfiler().pop();
                 }
             }
         }

--- a/src/main/java/com/leclowndu93150/particlerain/ClientStuff.java
+++ b/src/main/java/com/leclowndu93150/particlerain/ClientStuff.java
@@ -74,10 +74,7 @@ public class ClientStuff {
             if(event.phase == TickEvent.Phase.END){
                 Minecraft minecraft = Minecraft.getInstance();
                 if (!minecraft.isPaused() && minecraft.level != null && minecraft.getCameraEntity() != null) {
-                    // Profiler phase to find the source of lag when combined with other mods
-                    minecraft.getProfiler().push("updateWeatherParticles");
                     WeatherParticleSpawner.update(minecraft.level, minecraft.getCameraEntity(), minecraft.getFrameTimeNs());
-                    minecraft.getProfiler().pop();
                 }
             }
         }

--- a/src/main/java/com/leclowndu93150/particlerain/ParticleRainClient.java
+++ b/src/main/java/com/leclowndu93150/particlerain/ParticleRainClient.java
@@ -1,5 +1,8 @@
 package com.leclowndu93150.particlerain;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import me.shedaniel.autoconfig.AutoConfig;
 import me.shedaniel.autoconfig.serializer.JanksonConfigSerializer;
 import net.minecraftforge.api.distmarker.Dist;
@@ -16,6 +19,7 @@ public class ParticleRainClient{
     public static int particleCount;
     public static int fogCount;
     public static ModConfig config;
+    public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
 
     public ParticleRainClient() {
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();

--- a/src/main/java/com/leclowndu93150/particlerain/WeatherParticleSpawner.java
+++ b/src/main/java/com/leclowndu93150/particlerain/WeatherParticleSpawner.java
@@ -11,7 +11,6 @@ import net.minecraft.sounds.SoundEvents;
 import net.minecraft.tags.TagKey;
 import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
-import net.minecraft.util.profiling.ProfilerFiller;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.biome.Biome.Precipitation;
@@ -96,12 +95,8 @@ public final class WeatherParticleSpawner {
             }
 
             RandomSource rand = RandomSource.create();
-            
-            ProfilerFiller profiler = Minecraft.getInstance().getProfiler();
-            profiler.push("spawnRainParticles");
-            for (int pass = 0; pass < density; pass++) {
-                profiler.push("randomizeParticle");
 
+            for (int pass = 0; pass < density; pass++) {
                 float theta = (float) (2 * Math.PI * rand.nextFloat());
                 float phi = (float) Math.acos(2 * rand.nextFloat() - 1);
                 double x = ParticleRainClient.config.particleRadius * Mth.sin(phi) * Math.cos(theta);
@@ -109,16 +104,11 @@ public final class WeatherParticleSpawner {
                 double z = ParticleRainClient.config.particleRadius * Mth.cos(phi);
 
                 pos.set(x + entity.getX(), y + entity.getY(), z + entity.getZ());
-                if (level.getHeight(Heightmap.Types.MOTION_BLOCKING, pos.getX(), pos.getZ()) > pos.getY()) {
-                    profiler.pop();
+                if (level.getHeight(Heightmap.Types.MOTION_BLOCKING, pos.getX(), pos.getZ()) > pos.getY())
                     continue;
-                }
                 
-                profiler.popPush("spawnParticle");
                 spawnParticle(level, level.getBiome(pos), pos.getX() + rand.nextFloat(), pos.getY() + rand.nextFloat(), pos.getZ() + rand.nextFloat());
-                profiler.pop();
             }
-            profiler.pop();
         }
     }
 


### PR DESCRIPTION
The mod TerraFirmaCraft has a bug which causes world.getRainLevel() to return unreasonable values. This can cause pretty rain's particle system to create an insane amount of particles, lagging or crashing the game. I added a check to make sure the value of getRainLevel() is in bounds, and sent a warning and clamped the value if it was out of bounds. This prevents other mods from breaking the particle system in this way.