### PR TITLE
Fix getting game time in wrong units

### DIFF
--- a/src/main/java/com/leclowndu93150/particlerain/ClientStuff.java
+++ b/src/main/java/com/leclowndu93150/particlerain/ClientStuff.java
@@ -74,7 +74,7 @@ public class ClientStuff {
             if(event.phase == TickEvent.Phase.END){
                 Minecraft minecraft = Minecraft.getInstance();
                 if (!minecraft.isPaused() && minecraft.level != null && minecraft.getCameraEntity() != null) {
-                    WeatherParticleSpawner.update(minecraft.level, minecraft.getCameraEntity(), minecraft.getFrameTimeNs());
+                    WeatherParticleSpawner.update(minecraft.level, minecraft.getCameraEntity(), minecraft.getFrameTime());
                 }
             }
         }

--- a/src/main/java/com/leclowndu93150/particlerain/ParticleRainClient.java
+++ b/src/main/java/com/leclowndu93150/particlerain/ParticleRainClient.java
@@ -1,8 +1,5 @@
 package com.leclowndu93150.particlerain;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import me.shedaniel.autoconfig.AutoConfig;
 import me.shedaniel.autoconfig.serializer.JanksonConfigSerializer;
 import net.minecraftforge.api.distmarker.Dist;
@@ -19,7 +16,6 @@ public class ParticleRainClient{
     public static int particleCount;
     public static int fogCount;
     public static ModConfig config;
-    public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
 
     public ParticleRainClient() {
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();

--- a/src/main/java/com/leclowndu93150/particlerain/WeatherParticleSpawner.java
+++ b/src/main/java/com/leclowndu93150/particlerain/WeatherParticleSpawner.java
@@ -73,25 +73,17 @@ public final class WeatherParticleSpawner {
 
         if (level.isRaining() || ParticleRainClient.config.alwaysRaining) {
             int density;
-            
-            // A bug in TerraFirmaCraft causes level.getRainLevel() to return unreasonable values.
-            // To prevent other mods from breaking our particle system, clamp the value between 0 and 1.
-            float rainLevel = level.getRainLevel(partialTicks);
-            if (rainLevel < 0 || rainLevel > 1) {
-                ParticleRainClient.LOGGER.warn("World's rain level is out of bounds: " + rainLevel);
-                rainLevel = Mth.clamp(rainLevel, 0, 1);
-            }
 
             if (level.isThundering())
                 if (ParticleRainClient.config.alwaysRaining) {
                     density = ParticleRainClient.config.particleStormDensity;
                 } else {
-                    density = (int) (ParticleRainClient.config.particleStormDensity * rainLevel);
+                    density = (int) (ParticleRainClient.config.particleStormDensity * level.getRainLevel(partialTicks));
                 }
             else if (ParticleRainClient.config.alwaysRaining) {
                 density = ParticleRainClient.config.particleDensity;
             } else {
-                density = (int) (ParticleRainClient.config.particleDensity * rainLevel);
+                density = (int) (ParticleRainClient.config.particleDensity * level.getRainLevel(partialTicks));
             }
 
             RandomSource rand = RandomSource.create();


### PR DESCRIPTION
In the ClientStuff.java file, when updating the weather, a call to getFrameTimeNs() is made, but it needs to get the frame time in ticks instead. This PR replaces the call with a call to getFrameTime(), which gets the game time in the appropriate units. This bug was the cause of the bug I tried to fix in my previous PR, and since it's now fixed, I removed the check for out of bounds world rain values since it wasn't needed.

Branches for versions older than 1.20.1 made a call to getDeltaFrameTime() rather than either of the two functions I mentioned, which I believe is incorrect because the mod needs to know how long it has been since the last tick to lerp properly. Since this doesn't cause game freezes or crashes with other mods, and I can't tell if it causes problems as is, I didn't change those branches.