### PR TITLE
Get partialTicks with proper method

### DIFF
--- a/src/main/java/com/leclowndu93150/particlerain/ParticleRainClient.java
+++ b/src/main/java/com/leclowndu93150/particlerain/ParticleRainClient.java
@@ -86,7 +86,7 @@ public class ParticleRainClient {
     private void onClientTick(ClientTickEvent.Post event) {
         Minecraft minecraft = Minecraft.getInstance();
         if (!minecraft.isPaused() && minecraft.level != null && minecraft.getCameraEntity() != null) {
-            WeatherParticleSpawner.update(minecraft.level, minecraft.getCameraEntity(), minecraft.getFrameTime());
+            WeatherParticleSpawner.update(minecraft.level, minecraft.getCameraEntity(), minecraft.getDeltaTracker().getGameTimeDeltaPartialTick(true));
         }
     }
 


### PR DESCRIPTION
Previously I fixed a bug where partialTick calculations for weather were being done with a method to get nanoseconds, which was incorrect. I replaced this with a method getFrameTime(), which was renamed in 1.21.1 and renamed again in 1.21.4, which I didn't realize. The mod currently doesn't compile since I used the same method name in every version, this fixes it. Versions before 1.21 are unaffected.