### PR TITLE
Add TFC snow compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,8 @@ sourceSets.main.resources { srcDir 'src/generated/resources' }
 dependencies {
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
     implementation "curse.maven:cloth-config-348521:4973441"
+    implementation "curse.maven:tfc-302973:6739107"
+    runtimeOnly "curse.maven:tfc-302973:6739107"
 }
 
 mixin {

--- a/src/main/java/com/leclowndu93150/particlerain/ParticleRainClient.java
+++ b/src/main/java/com/leclowndu93150/particlerain/ParticleRainClient.java
@@ -4,7 +4,9 @@ import me.shedaniel.autoconfig.AutoConfig;
 import me.shedaniel.autoconfig.serializer.JanksonConfigSerializer;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.fml.loading.FMLLoader;
@@ -26,10 +28,15 @@ public class ParticleRainClient{
             AutoConfig.getConfigHolder(ModConfig.class).registerSaveListener(ClientStuff::saveListener);
         }
         modEventBus.addListener(this::commonSetup);
+        modEventBus.addListener(this::clientSetup);
         ParticleRegistry.register(modEventBus);
     }
 
     private void commonSetup(final FMLCommonSetupEvent event) {
         event.enqueueWork(NetworkHandler::init);
+    }
+
+    private void clientSetup(final FMLClientSetupEvent event) {
+        WeatherParticleSpawner.isTFCloaded = ModList.get().isLoaded("tfc");
     }
 }

--- a/src/main/templates/META-INF/mods.toml
+++ b/src/main/templates/META-INF/mods.toml
@@ -76,6 +76,13 @@ versionRange = "*"
 ordering = "NONE"
 side = "BOTH"
 
+[[dependencies."${mod_id}"]]
+modId = "tfc"
+mandatory = false
+versionRange = "*"
+ordering = "NONE"
+side = "CLIENT"
+
 # Features are specific properties of the game environment, that you may want to declare you require. This example declares
 # that your mod requires GL version 3.2 or higher. Other features will be added. They are side aware so declaring this won't
 # stop your mod loading on the server for example.


### PR DESCRIPTION
The TerraFirmaCraft mod uses its own weather and climate system to determine if it should snow or rain, which doesn't work with pretty rain because it uses a vanilla method of biomes to determine whether it should be snowing or raining. There isn't a way to fix this without TFC specific integration, so I added it.

These changes have no effect without TFC installed, it's tested and working with and without it installed. For some reason adding TFC as a dependency broke the runClient gradle task, which I couldn't figure out, but the build task works and the mod works fine.